### PR TITLE
Evans updates to Pycroft's PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # OG-USA
 
-OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Documentation of the model theory--its output, and solution method--is available [here](https://github.com/PSLmodels/OG-USA/blob/master/docs/OGUSAdoc.pdf) and is regularly updated.  Documentation for the Python API for OG-USA is available [here](https://og-usa.readthedocs.io/en/latest/index.html).
+OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Regularly updated documentation of the model theory--its output, and solution method--and the Python API is available [here](https://pslmodels.github.io/OG-USA).
 
 
 ## Disclaimer

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,8 @@ dependencies:
 - python>=3.7.7
 - ipython
 - setuptools
+- importlib
+- pathlib
 - mkl>=2020.2
 - psutil
 - scipy>=1.5.0

--- a/ogusa/tests/test_run_example.py
+++ b/ogusa/tests/test_run_example.py
@@ -1,12 +1,20 @@
-#### import modules (same as run_ogusa_example)
+'''
+This test checks whether starting the run_ogusa_example.py script run without
+shutting down for 5 minutes (300 seconds)
+'''
+# Import packages
 import multiprocessing
 import time
-import os, sys
+import importlib
+import os
+from pathlib import Path
 
-# currentdir = os.path.dirname(os.path.realpath(__file__))
-# parentdir = os.path.dirname(currentdir)
-# sys.path.append(parentdir)
-from run_examples import run_ogusa_example
+# Import run_ogusa_example.py, which is not part of the ogusa package
+OG_USA_path = Path(__file__).parents[2]
+run_examples_path = os.path.join(OG_USA_path, 'run_examples')
+print('Test directory is :', run_examples_path)
+module_path = os.path.join(run_examples_path, 'run_ogusa_example.py')
+run_ogusa_example = importlib.import_module(module_path)
 
 
 def call_run_ogusa_example():

--- a/ogusa/tests/test_run_example.py
+++ b/ogusa/tests/test_run_example.py
@@ -1,3 +1,8 @@
+'''
+This test tests whether starting a `run_ogusa_example.py` run of the model does
+not break down (is still running) after 5 minutes or 300 seconds.
+'''
+
 import multiprocessing
 import time
 import os, sys

--- a/ogusa/tests/test_run_example.py
+++ b/ogusa/tests/test_run_example.py
@@ -1,20 +1,11 @@
 #### import modules (same as run_ogusa_example)
 import multiprocessing
-from distributed import Client
 import time
-import numpy as np
 import os, sys
-import taxcalc
-from taxcalc import Calculator
-from ogusa import output_tables as ot
-from ogusa import output_plots as op
-from ogusa.execute import runner
-from ogusa.constants import REFORM_DIR, BASELINE_DIR
-from ogusa.utils import safe_read_pickle
 
-currentdir = os.path.dirname(os.path.realpath(__file__))
-parentdir = os.path.dirname(currentdir)
-sys.path.append(parentdir)
+# currentdir = os.path.dirname(os.path.realpath(__file__))
+# parentdir = os.path.dirname(currentdir)
+# sys.path.append(parentdir)
 from run_examples import run_ogusa_example
 
 
@@ -26,18 +17,17 @@ def test_run_ogusa_example(f = call_run_ogusa_example):
     '''
     test that run_ogusa_example runs for at least 5 minutes
     '''
-    p = multiprocessing.Process(target = f, 
+    p = multiprocessing.Process(target = f,
                                 name="run_ogusa_example", args=())
     p.start()
     time.sleep(300)
     if p.is_alive():
-        p.terminate() 
+        p.terminate()
         p.join()
         timetest = True
     else:
         print("run_ogusa_example did not run for minimum time")
         timetest = False
     print('timetest ==', timetest)
-    
-    assert timetest == True
 
+    assert timetest == True


### PR DESCRIPTION
@jpycroft . This PR does really only one thing. It adds `importlib` and `pathlib` to the `environment.yml` file because these are added to your test. This fix passes the `test_run_example.py` test on my machine locally when I rebuild the conda environment with these changes.

I also added a little bit of cleanup to the PR by merging in the changes from PR [#640](https://github.com/PSLmodels/OG-USA/pull/640) that was merged into the master yesterday (just a change to the `README.md`). And I added a docstring at the top of the `test_run_example.py` file. My text editor automatically made some other small changes to the `test_run_example.py` file like getting rid of extra spaces at the end of lines and extra blank lines. No changes of substance to `test_run_example.py`.

I was not able to get this to run on Travis CI on my fork in the cloud. But I recommend that you merge this PR into your `jptest` branch. Then those changes will be automatically updated into your PR. Then we can see if the CI tests pass on your PR. If the CI tests don't pass, then you can just do another commit to this PR that gets rid of those two import statements in the `environment.yml` file.

cc: @jdebacker